### PR TITLE
Fix boilerplate controller

### DIFF
--- a/controllers/README.md
+++ b/controllers/README.md
@@ -36,7 +36,7 @@ describe('SampleController', function() {
         scope = $rootScope.$new();
 
         // load the SampleController mocking the $scope to the one created before
-        ctrl = $controller('SampleController', {
+        ctrl = _$controller_('SampleController', {
             $scope: scope
         };
     }));


### PR DESCRIPTION
When we use $controller variable karma throws that error
ReferenceError: Can't find variable: $controller

Just changed $controller to _$controller_
